### PR TITLE
Remove max_size parameter

### DIFF
--- a/adafruit_dash_display.py
+++ b/adafruit_dash_display.py
@@ -136,7 +136,7 @@ class Hub:  # pylint: disable=too-many-instance-attributes
 
         self.display.show(None)
 
-        self.splash = displayio.Group(max_size=25)
+        self.splash = displayio.Group()
 
         self.rect = Rect(0, 0, 240, 30, fill=0xFFFFFF)
         self.splash.append(self.rect)

--- a/examples/client_examples/battery_daughter.py
+++ b/examples/client_examples/battery_daughter.py
@@ -94,7 +94,7 @@ BORDER = 2
 
 display = adafruit_displayio_ssd1306.SSD1306(display_bus, width=WIDTH, height=HEIGHT)
 
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 digital_label = label.Label(

--- a/examples/dash_display_advancedtest.py
+++ b/examples/dash_display_advancedtest.py
@@ -36,7 +36,7 @@ except ImportError:
     print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 
-rgb_group = displayio.Group(max_size=9)
+rgb_group = displayio.Group()
 R_label = Label(
     terminalio.FONT,
     text="   +\nR:\n   -",


### PR DESCRIPTION
Remove the `max_size` parameter. It is no longer used by `displayio.Group`
Ref: adafruit/circuitpython#4959

I don't have a FunHouse to test this with.