### PR TITLE
Fix pylint error

### DIFF
--- a/adafruit_dash_display.py
+++ b/adafruit_dash_display.py
@@ -114,6 +114,7 @@ class Feed:
 class Hub:  # pylint: disable=too-many-instance-attributes
     """Object that lets you make an IOT dashboard"""
 
+    # pylint: disable=invalid-name
     def __init__(self, display, io, nav):
         self.display = display
 


### PR DESCRIPTION
Fixes the following `pylint` errors:

```
************* Module adafruit_dash_display
Error: adafruit_dash_display.py:117:32: C0103: Argument name "io" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
```