### PR TITLE
Add type annotations to adafruit_dash_display

### DIFF
--- a/adafruit_dash_display.py
+++ b/adafruit_dash_display.py
@@ -25,6 +25,7 @@ Implementation Notes
 try:
     from typing import Tuple, Callable, Optional, Any
     from adafruit_io.adafruit_io import IO_MQTT
+    from digitalio import DigitalInOut
 except ImportError:
     pass
 
@@ -32,7 +33,6 @@ import time
 from collections import OrderedDict
 import displayio
 import terminalio
-import digitalio
 from adafruit_display_shapes.rect import Rect
 from adafruit_display_text.label import Label
 
@@ -132,7 +132,7 @@ class Hub:  # pylint: disable=too-many-instance-attributes
         self,
         display: displayio.Display,
         io: IO_MQTT,
-        nav: Tuple[digitalio.DigitalInOut, ...],
+        nav: Tuple[DigitalInOut, ...],
     ):
         self.display = display
 

--- a/adafruit_dash_display.py
+++ b/adafruit_dash_display.py
@@ -22,13 +22,19 @@ Implementation Notes
   https://github.com/adafruit/circuitpython/releases
 
 """
+try:
+    from typing import Tuple, Callable, Optional, Any
+except ImportError:
+    pass
 
 import time
 from collections import OrderedDict
-from adafruit_display_shapes.rect import Rect
-from adafruit_display_text.label import Label
 import displayio
 import terminalio
+import digitalio
+from adafruit_display_shapes.rect import Rect
+from adafruit_display_text.label import Label
+from adafruit_io.adafruit_io import IO_MQTT
 
 __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Dash_Display.git"
@@ -38,7 +44,14 @@ class Feed:
     """Feed object to make getting and setting different feed properties easier"""
 
     def __init__(
-        self, key, default_text, formatted_text, callback, color, pub, index
+        self,
+        key: str,
+        default_text: str,
+        formatted_text: str,
+        callback: Optional[Callable],
+        color: Optional[int],
+        pub: Optional[Callable],
+        index: int,
     ):  # pylint: disable=too-many-arguments
         self._key = key
         self.default_text = default_text
@@ -56,7 +69,7 @@ class Feed:
         return self._key
 
     @key.setter
-    def key(self, value):
+    def key(self, value: str):
         """Setter for feed key. Sets a new value for the feed key property _key"""
         self._key = value
 
@@ -66,7 +79,7 @@ class Feed:
         return self._text
 
     @text.setter
-    def text(self, value):
+    def text(self, value: str):
         """Setter for text ready to be formatted. Allows to change the feed text"""
         self._text = value
 
@@ -76,7 +89,7 @@ class Feed:
         return self._callback
 
     @callback.setter
-    def callback(self, value):
+    def callback(self, value: Callable):
         """Setter for callback function. Changes the feed callback"""
         self._callback = value
 
@@ -86,7 +99,7 @@ class Feed:
         return self._color
 
     @color.setter
-    def color(self, value):
+    def color(self, value: int):
         """Setter for text color callback function"""
         self._color = value
 
@@ -96,7 +109,7 @@ class Feed:
         return self._pub
 
     @pub.setter
-    def pub(self, value):
+    def pub(self, value: Callable):
         """Setter for publish function"""
         self._pub = value
 
@@ -106,7 +119,7 @@ class Feed:
         return self._last_val
 
     @last_val.setter
-    def last_val(self, value):
+    def last_val(self, value: str):
         """Setter for last received value"""
         self._last_val = value
 
@@ -115,7 +128,12 @@ class Hub:  # pylint: disable=too-many-instance-attributes
     """Object that lets you make an IOT dashboard"""
 
     # pylint: disable=invalid-name
-    def __init__(self, display, io, nav):
+    def __init__(
+        self,
+        display: displayio.Display,
+        io: IO_MQTT,
+        nav: Tuple[digitalio.DigitalInOut, ...],
+    ):
         self.display = display
 
         self.io = io  # pylint: disable=invalid-name
@@ -145,7 +163,7 @@ class Hub:  # pylint: disable=too-many-instance-attributes
         self.display.show(self.splash)
 
     def simple_text_callback(
-        self, client, feed_id, message
+        self, client: Any, feed_id: str, message: str
     ):  # pylint: disable=unused-argument
         """Default callback function that uses the text in the Feed object and the color callback
         to set the text"""
@@ -157,7 +175,7 @@ class Hub:  # pylint: disable=too-many-instance-attributes
             text = feed.text.format(float(message))
         return text
 
-    def update_text(self, client, feed_id, message):
+    def update_text(self, client: Any, feed_id: str, message: str):
         """Updates the text on the display"""
         feed = self.feeds[feed_id]
         feed.callback(client, feed_id, message)
@@ -165,17 +183,17 @@ class Hub:  # pylint: disable=too-many-instance-attributes
         if feed.color:
             self.splash[feed.index + 1].color = feed.color(message)
 
-    def base_pub(self, var):
+    def base_pub(self, var: Any):
         """Default function called when a feed is published to"""
 
     def add_device(
         self,
-        feed_key,
-        default_text=None,
-        formatted_text=None,
-        color_callback=None,
-        callback=None,
-        pub_method=None,
+        feed_key: str,
+        default_text: Optional[str] = None,
+        formatted_text: Optional[str] = None,
+        color_callback: Optional[int] = None,
+        callback: Optional[Callable] = None,
+        pub_method: Optional[Callable] = None,
     ):  # pylint: disable=too-many-arguments
         """Adds a feed/device to the UI"""
         if not callback:
@@ -234,21 +252,21 @@ class Hub:  # pylint: disable=too-many-instance-attributes
 
     # pylint: disable=unused-argument
     @staticmethod
-    def connected(client):
+    def connected(client: Any):
         """Callback for when the device is connected to Adafruit IO"""
         print("Connected to Adafruit IO!")
 
     @staticmethod
-    def subscribe(client, userdata, topic, granted_qos):
+    def subscribe(client: Any, userdata: Any, topic: str, granted_qos: str):
         """Callback for when a new feed is subscribed to"""
         print("Subscribed to {0} with QOS level {1}".format(topic, granted_qos))
 
     @staticmethod
-    def disconnected(client):
+    def disconnected(client: Any):
         """Callback for when the device disconnects from Adafruit IO"""
         print("Disconnected from Adafruit IO!")
 
-    def message(self, client, feed_id, message):
+    def message(self, client: Any, feed_id: str, message: str):
         """Callback for whenever a new message is received"""
         print("Feed {0} received new value: {1}".format(feed_id, message))
         feed_id = feed_id.split("/")[-1]
@@ -256,7 +274,7 @@ class Hub:  # pylint: disable=too-many-instance-attributes
         feed.last_val = message
         self.update_text(client, feed_id, str(message))
 
-    def publish(self, feed, message):
+    def publish(self, feed: Feed, message: str):
         """Callback for publishing a message"""
         print(f"Publishing {message} to {feed}")
         self.io.publish(feed, message)

--- a/adafruit_dash_display.py
+++ b/adafruit_dash_display.py
@@ -24,6 +24,7 @@ Implementation Notes
 """
 try:
     from typing import Tuple, Callable, Optional, Any
+    from adafruit_io.adafruit_io import IO_MQTT
 except ImportError:
     pass
 
@@ -34,7 +35,6 @@ import terminalio
 import digitalio
 from adafruit_display_shapes.rect import Rect
 from adafruit_display_text.label import Label
-from adafruit_io.adafruit_io import IO_MQTT
 
 __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Dash_Display.git"
@@ -163,7 +163,7 @@ class Hub:  # pylint: disable=too-many-instance-attributes
         self.display.show(self.splash)
 
     def simple_text_callback(
-        self, client: Any, feed_id: str, message: str
+        self, client: IO_MQTT, feed_id: str, message: str
     ):  # pylint: disable=unused-argument
         """Default callback function that uses the text in the Feed object and the color callback
         to set the text"""
@@ -175,7 +175,7 @@ class Hub:  # pylint: disable=too-many-instance-attributes
             text = feed.text.format(float(message))
         return text
 
-    def update_text(self, client: Any, feed_id: str, message: str):
+    def update_text(self, client: IO_MQTT, feed_id: str, message: str):
         """Updates the text on the display"""
         feed = self.feeds[feed_id]
         feed.callback(client, feed_id, message)
@@ -252,21 +252,21 @@ class Hub:  # pylint: disable=too-many-instance-attributes
 
     # pylint: disable=unused-argument
     @staticmethod
-    def connected(client: Any):
+    def connected(client: IO_MQTT):
         """Callback for when the device is connected to Adafruit IO"""
         print("Connected to Adafruit IO!")
 
     @staticmethod
-    def subscribe(client: Any, userdata: Any, topic: str, granted_qos: str):
+    def subscribe(client: IO_MQTT, userdata: Any, topic: str, granted_qos: str):
         """Callback for when a new feed is subscribed to"""
         print("Subscribed to {0} with QOS level {1}".format(topic, granted_qos))
 
     @staticmethod
-    def disconnected(client: Any):
+    def disconnected(client: IO_MQTT):
         """Callback for when the device disconnects from Adafruit IO"""
         print("Disconnected from Adafruit IO!")
 
-    def message(self, client: Any, feed_id: str, message: str):
+    def message(self, client: IO_MQTT, feed_id: str, message: str):
         """Callback for whenever a new message is received"""
         print("Feed {0} received new value: {1}".format(feed_id, message))
         feed_id = feed_id.split("/")[-1]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@
 Adafruit-Blinka
 adafruit-circuitpython-display-text
 adafruit-circuitpython-display-shapes
+adafruit-circuitpython-adafruitio


### PR DESCRIPTION
Adds type annotations to library `adafruit_dash_display.py`, closes #3.
