### PR TITLE
Update argument/attribute name, add Hub class param descriptions

### DIFF
--- a/adafruit_dash_display.py
+++ b/adafruit_dash_display.py
@@ -133,6 +133,14 @@ class Hub:  # pylint: disable=too-many-instance-attributes
         io_object: IO_MQTT,
         nav: Tuple[DigitalInOut, ...],
     ):
+        """
+        Object that lets you make an IOT dashboard
+
+        :param display: The display object.
+        :param io_object: The io object.
+        :param nav: The navigation buttons.
+
+        """
         self.display = display
 
         self.io_object = io_object

--- a/adafruit_dash_display.py
+++ b/adafruit_dash_display.py
@@ -127,16 +127,15 @@ class Feed:
 class Hub:  # pylint: disable=too-many-instance-attributes
     """Object that lets you make an IOT dashboard"""
 
-    # pylint: disable=invalid-name
     def __init__(
         self,
         display: displayio.Display,
-        io: IO_MQTT,
+        io_object: IO_MQTT,
         nav: Tuple[DigitalInOut, ...],
     ):
         self.display = display
 
-        self.io = io  # pylint: disable=invalid-name
+        self.io_object = io_object
 
         self.up_btn, self.select, self.down, self.back, self.submit = nav
 
@@ -145,13 +144,13 @@ class Hub:  # pylint: disable=too-many-instance-attributes
 
         self.feeds = OrderedDict()
 
-        self.io.on_mqtt_connect = self.connected
-        self.io.on_mqtt_disconnect = self.disconnected
-        self.io.on_mqtt_subscribe = self.subscribe
-        self.io.on_message = self.message
+        self.io_object.on_mqtt_connect = self.connected
+        self.io_object.on_mqtt_disconnect = self.disconnected
+        self.io_object.on_mqtt_subscribe = self.subscribe
+        self.io_object.on_message = self.message
 
         print("Connecting to Adafruit IO...")
-        io.connect()
+        io_object.connect()
 
         self.display.show(None)
 
@@ -206,7 +205,7 @@ class Hub:  # pylint: disable=too-many-instance-attributes
         if not default_text:
             default_text = feed_key
 
-        self.io.subscribe(feed_key)
+        self.io_object.subscribe(feed_key)
         if len(self.splash) == 1:
             self.splash.append(
                 Label(
@@ -246,9 +245,9 @@ class Hub:  # pylint: disable=too-many-instance-attributes
         """Gets all the subscribed feeds"""
         for feed in self.feeds.keys():
             print(f"getting {feed}")
-            self.io.get(feed)
+            self.io_object.get(feed)
             time.sleep(0.1)
-        self.io.loop()
+        self.io_object.loop()
 
     # pylint: disable=unused-argument
     @staticmethod
@@ -277,11 +276,11 @@ class Hub:  # pylint: disable=too-many-instance-attributes
     def publish(self, feed: Feed, message: str):
         """Callback for publishing a message"""
         print(f"Publishing {message} to {feed}")
-        self.io.publish(feed, message)
+        self.io_object.publish(feed, message)
 
     def loop(self):
         """Loops Adafruit IO and also checks to see if any buttons have been pressed"""
-        self.io.loop()
+        self.io_object.loop()
         if self.select.value:
             feed = self.feeds[list(self.feeds.keys())[self.selected - 1]]
             if feed.pub:


### PR DESCRIPTION
The argument/attribute name `io` does not conform to naming standards for either type of object. The preferred length of these types of names is three or more characters. As it is the `io` object, I updated it to `io_object`. 

While updating this, I noticed that there were no parameter descriptions in the `Hub` class, so I added those as well.