### PR TITLE
Update examples to work with settings.toml

### DIFF
--- a/examples/dash_display_advancedtest.py
+++ b/examples/dash_display_advancedtest.py
@@ -35,12 +35,12 @@ submit = touchio.TouchIn(board.CAP8)
 # tokens used by this Demo: CIRCUITPY_WIFI_SSID, CIRCUITPY_WIFI_PASSWORD
 #                           CIRCUITPY_AIO_USERNAME, CIRCUITPY_AIO_KEY
 secrets = {}
-for token in ["ssid", "password"]:
-    if getenv("CIRCUITPY_WIFI_" + token.upper()):
-        secrets[token] = getenv("CIRCUITPY_WIFI_" + token.upper())
-for token in ["aio_username", "aio_key"]:
-    if getenv("CIRCUITPY_" + token.upper()):
-        secrets[token] = getenv("CIRCUITPY_" + token.upper())
+for token in ["SSID", "PASSWORD"]:
+    if getenv("CIRCUITPY_WIFI_" + token):
+        secrets[token.lower()] = getenv("CIRCUITPY_WIFI_" + token)
+for token in ["AIO_USERNAME", "AIO_KEY"]:
+    if getenv("CIRCUITPY_" + token):
+        secrets[token.lower()] = getenv("CIRCUITPY_" + token)
 
 if not secrets:
     try:

--- a/examples/dash_display_advancedtest.py
+++ b/examples/dash_display_advancedtest.py
@@ -3,6 +3,7 @@
 
 import time
 import ssl
+from os import getenv
 import displayio
 import board
 from digitalio import DigitalInOut, Direction, Pull
@@ -30,11 +31,24 @@ down.pull = Pull.DOWN
 back = touchio.TouchIn(board.CAP7)
 submit = touchio.TouchIn(board.CAP8)
 
-try:
-    from secrets import secrets
-except ImportError:
-    print("WiFi secrets are kept in secrets.py, please add them there!")
-    raise
+# Get wifi details and more from a settings.toml file
+# tokens used by this Demo: CIRCUITPY_WIFI_SSID, CIRCUITPY_WIFI_PASSWORD
+#                           CIRCUITPY_AIO_USERNAME, CIRCUITPY_AIO_KEY
+secrets = {}
+for token in ["ssid", "password"]:
+    if getenv("CIRCUITPY_WIFI_" + token.upper()):
+        secrets[token] = getenv("CIRCUITPY_WIFI_" + token.upper())
+for token in ["aio_username", "aio_key"]:
+    if getenv("CIRCUITPY_" + token.upper()):
+        secrets[token] = getenv("CIRCUITPY_" + token.upper())
+
+if not secrets:
+    try:
+        # Fallback on secrets.py until depreciation is over and option is removed
+        from secrets import secrets
+    except ImportError:
+        print("WiFi secrets are kept in settings.toml, please add them there!")
+        raise
 
 rgb_group = displayio.Group()
 R_label = Label(
@@ -171,7 +185,7 @@ def pub_lamp(lamp):
 
 display = board.DISPLAY
 
-# Set your Adafruit IO Username and Key in secrets.py
+# Set your Adafruit IO Username and Key in settings.toml
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)
 aio_username = secrets["aio_username"]

--- a/examples/dash_display_client_examples/battery_daughter.py
+++ b/examples/dash_display_client_examples/battery_daughter.py
@@ -27,12 +27,12 @@ displayio.release_displays()
 # tokens used by this Demo: CIRCUITPY_WIFI_SSID, CIRCUITPY_WIFI_PASSWORD
 #                           CIRCUITPY_AIO_USERNAME, CIRCUITPY_AIO_KEY
 secrets = {}
-for token in ["ssid", "password"]:
-    if getenv("CIRCUITPY_WIFI_" + token.upper()):
-        secrets[token] = getenv("CIRCUITPY_WIFI_" + token.upper())
-for token in ["aio_username", "aio_key"]:
-    if getenv("CIRCUITPY_" + token.upper()):
-        secrets[token] = getenv("CIRCUITPY_" + token.upper())
+for token in ["SSID", "PASSWORD"]:
+    if getenv("CIRCUITPY_WIFI_" + token):
+        secrets[token.lower()] = getenv("CIRCUITPY_WIFI_" + token)
+for token in ["AIO_USERNAME", "AIO_KEY"]:
+    if getenv("CIRCUITPY_" + token):
+        secrets[token.lower()] = getenv("CIRCUITPY_" + token)
 
 if not secrets:
     try:

--- a/examples/dash_display_client_examples/battery_daughter.py
+++ b/examples/dash_display_client_examples/battery_daughter.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import time
+from os import getenv
 import board
 from adafruit_lc709203f import LC709203F
 import busio
@@ -22,25 +23,54 @@ displayio.release_displays()
 
 ### WiFi ###
 
-# Get wifi details and more from a secrets.py file
-try:
-    from secrets import secrets
-except ImportError:
-    print("WiFi secrets are kept in secrets.py, please add them there!")
-    raise
+# Get wifi details and more from a settings.toml file
+# tokens used by this Demo: CIRCUITPY_WIFI_SSID, CIRCUITPY_WIFI_PASSWORD
+#                           CIRCUITPY_AIO_USERNAME, CIRCUITPY_AIO_KEY
+secrets = {}
+for token in ["ssid", "password"]:
+    if getenv("CIRCUITPY_WIFI_" + token.upper()):
+        secrets[token] = getenv("CIRCUITPY_WIFI_" + token.upper())
+for token in ["aio_username", "aio_key"]:
+    if getenv("CIRCUITPY_" + token.upper()):
+        secrets[token] = getenv("CIRCUITPY_" + token.upper())
 
+if not secrets:
+    try:
+        # Fallback on secrets.py until depreciation is over and option is removed
+        from secrets import secrets
+    except ImportError:
+        print("WiFi secrets are kept in settings.toml, please add them there!")
+        raise
 
 # If you are using a board with pre-defined ESP32 Pins:
-esp32_cs = DigitalInOut(board.D13)
-esp32_ready = DigitalInOut(board.D11)
-esp32_reset = DigitalInOut(board.D12)
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 
-spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+# If you have an externally connected ESP32:
+# esp32_cs = DigitalInOut(board.D13)
+# esp32_ready = DigitalInOut(board.D11)
+# esp32_reset = DigitalInOut(board.D12)
+
+# Secondary (SCK1) SPI used to connect to WiFi board on Arduino Nano Connect RP2040
+if "SCK1" in dir(board):
+    spi = busio.SPI(board.SCK1, board.MOSI1, board.MISO1)
+else:
+    spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
+
 """Use below for Most Boards"""
-status_light = neopixel.NeoPixel(
-    board.NEOPIXEL, 1, brightness=0.2
-)  # Uncomment for Most Boards
+status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2)
+"""Uncomment below for ItsyBitsy M4"""
+# status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
+"""Uncomment below for an externally defined RGB LED (including Arduino Nano Connect)"""
+# import adafruit_rgbled
+# from adafruit_esp32spi import PWMOut
+# RED_LED = PWMOut.PWMOut(esp, 26)
+# GREEN_LED = PWMOut.PWMOut(esp, 27)
+# BLUE_LED = PWMOut.PWMOut(esp, 25)
+# status_light = adafruit_rgbled.RGBLED(RED_LED, BLUE_LED, GREEN_LED)
+
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
 
 
@@ -74,7 +104,6 @@ mqtt_client = MQTT.MQTT(
     password=secrets["aio_key"],
 )
 
-
 # Initialize an Adafruit IO MQTT Client
 io = IO_MQTT(mqtt_client)
 
@@ -104,7 +133,6 @@ digital_label = label.Label(
 splash.append(digital_label)
 alarm_label = label.Label(terminalio.FONT, text="Voltage: ", color=0xFFFFFF, x=4, y=14)
 splash.append(alarm_label)
-
 
 sensor = LC709203F(board.I2C())
 

--- a/examples/dash_display_client_examples/door_daughter.py
+++ b/examples/dash_display_client_examples/door_daughter.py
@@ -19,12 +19,12 @@ from adafruit_debouncer import Debouncer
 # tokens used by this Demo: CIRCUITPY_WIFI_SSID, CIRCUITPY_WIFI_PASSWORD
 #                           CIRCUITPY_AIO_USERNAME, CIRCUITPY_AIO_KEY
 secrets = {}
-for token in ["ssid", "password"]:
-    if getenv("CIRCUITPY_WIFI_" + token.upper()):
-        secrets[token] = getenv("CIRCUITPY_WIFI_" + token.upper())
-for token in ["aio_username", "aio_key"]:
-    if getenv("CIRCUITPY_" + token.upper()):
-        secrets[token] = getenv("CIRCUITPY_" + token.upper())
+for token in ["SSID", "PASSWORD"]:
+    if getenv("CIRCUITPY_WIFI_" + token):
+        secrets[token.lower()] = getenv("CIRCUITPY_WIFI_" + token)
+for token in ["AIO_USERNAME", "AIO_KEY"]:
+    if getenv("CIRCUITPY_" + token):
+        secrets[token.lower()] = getenv("CIRCUITPY_" + token)
 
 if not secrets:
     try:

--- a/examples/dash_display_client_examples/door_daughter.py
+++ b/examples/dash_display_client_examples/door_daughter.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2021 Eva Herrada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
+from os import getenv
 import board
 import busio
 from adafruit_esp32spi import adafruit_esp32spi
@@ -14,12 +15,24 @@ from adafruit_debouncer import Debouncer
 
 ### WiFi ###
 
-# Get wifi details and more from a secrets.py file
-try:
-    from secrets import secrets
-except ImportError:
-    print("WiFi secrets are kept in secrets.py, please add them there!")
-    raise
+# Get wifi details and more from a settings.toml file
+# tokens used by this Demo: CIRCUITPY_WIFI_SSID, CIRCUITPY_WIFI_PASSWORD
+#                           CIRCUITPY_AIO_USERNAME, CIRCUITPY_AIO_KEY
+secrets = {}
+for token in ["ssid", "password"]:
+    if getenv("CIRCUITPY_WIFI_" + token.upper()):
+        secrets[token] = getenv("CIRCUITPY_WIFI_" + token.upper())
+for token in ["aio_username", "aio_key"]:
+    if getenv("CIRCUITPY_" + token.upper()):
+        secrets[token] = getenv("CIRCUITPY_" + token.upper())
+
+if not secrets:
+    try:
+        # Fallback on secrets.py until depreciation is over and option is removed
+        from secrets import secrets
+    except ImportError:
+        print("WiFi secrets are kept in settings.toml, please add them there!")
+        raise
 
 switch_pin = DigitalInOut(board.D10)
 switch_pin.direction = Direction.INPUT
@@ -27,16 +40,34 @@ switch_pin.pull = Pull.UP
 switch = Debouncer(switch_pin)
 
 # If you are using a board with pre-defined ESP32 Pins:
-esp32_cs = DigitalInOut(board.D13)
-esp32_ready = DigitalInOut(board.D11)
-esp32_reset = DigitalInOut(board.D12)
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 
-spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+# If you have an externally connected ESP32:
+# esp32_cs = DigitalInOut(board.D13)
+# esp32_ready = DigitalInOut(board.D11)
+# esp32_reset = DigitalInOut(board.D12)
+
+# Secondary (SCK1) SPI used to connect to WiFi board on Arduino Nano Connect RP2040
+if "SCK1" in dir(board):
+    spi = busio.SPI(board.SCK1, board.MOSI1, board.MISO1)
+else:
+    spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
+
 """Use below for Most Boards"""
-status_light = neopixel.NeoPixel(
-    board.NEOPIXEL, 1, brightness=0.2
-)  # Uncomment for Most Boards
+status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2)
+"""Uncomment below for ItsyBitsy M4"""
+# status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
+"""Uncomment below for an externally defined RGB LED (including Arduino Nano Connect)"""
+# import adafruit_rgbled
+# from adafruit_esp32spi import PWMOut
+# RED_LED = PWMOut.PWMOut(esp, 26)
+# GREEN_LED = PWMOut.PWMOut(esp, 27)
+# BLUE_LED = PWMOut.PWMOut(esp, 25)
+# status_light = adafruit_rgbled.RGBLED(RED_LED, BLUE_LED, GREEN_LED)
+
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
 
 # Connect to WiFi

--- a/examples/dash_display_client_examples/neopixel_daughter.py
+++ b/examples/dash_display_client_examples/neopixel_daughter.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2021 Eva Herrada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
+from os import getenv
 import board
 import busio
 from adafruit_esp32spi import adafruit_esp32spi
@@ -13,26 +14,56 @@ from digitalio import DigitalInOut
 
 ### WiFi ###
 
-# Get wifi details and more from a secrets.py file
-try:
-    from secrets import secrets
-except ImportError:
-    print("WiFi secrets are kept in secrets.py, please add them there!")
-    raise
+# Get wifi details and more from a settings.toml file
+# tokens used by this Demo: CIRCUITPY_WIFI_SSID, CIRCUITPY_WIFI_PASSWORD
+#                           CIRCUITPY_AIO_USERNAME, CIRCUITPY_AIO_KEY
+secrets = {}
+for token in ["ssid", "password"]:
+    if getenv("CIRCUITPY_WIFI_" + token.upper()):
+        secrets[token] = getenv("CIRCUITPY_WIFI_" + token.upper())
+for token in ["aio_username", "aio_key"]:
+    if getenv("CIRCUITPY_" + token.upper()):
+        secrets[token] = getenv("CIRCUITPY_" + token.upper())
+
+if not secrets:
+    try:
+        # Fallback on secrets.py until depreciation is over and option is removed
+        from secrets import secrets
+    except ImportError:
+        print("WiFi secrets are kept in settings.toml, please add them there!")
+        raise
 
 pixels = neopixel.NeoPixel(board.D5, 300)
 
 # If you are using a board with pre-defined ESP32 Pins:
-esp32_cs = DigitalInOut(board.D13)
-esp32_ready = DigitalInOut(board.D11)
-esp32_reset = DigitalInOut(board.D12)
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 
-spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+# If you have an externally connected ESP32:
+# esp32_cs = DigitalInOut(board.D13)
+# esp32_ready = DigitalInOut(board.D11)
+# esp32_reset = DigitalInOut(board.D12)
+
+# Secondary (SCK1) SPI used to connect to WiFi board on Arduino Nano Connect RP2040
+if "SCK1" in dir(board):
+    spi = busio.SPI(board.SCK1, board.MOSI1, board.MISO1)
+else:
+    spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
+
 """Use below for Most Boards"""
-status_light = neopixel.NeoPixel(
-    board.NEOPIXEL, 1, brightness=0.2
-)  # Uncomment for Most Boards
+status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2)
+"""Uncomment below for ItsyBitsy M4"""
+# status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
+"""Uncomment below for an externally defined RGB LED (including Arduino Nano Connect)"""
+# import adafruit_rgbled
+# from adafruit_esp32spi import PWMOut
+# RED_LED = PWMOut.PWMOut(esp, 26)
+# GREEN_LED = PWMOut.PWMOut(esp, 27)
+# BLUE_LED = PWMOut.PWMOut(esp, 25)
+# status_light = adafruit_rgbled.RGBLED(RED_LED, BLUE_LED, GREEN_LED)
+
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
 
 
@@ -70,7 +101,6 @@ mqtt_client = MQTT.MQTT(
     username=secrets["aio_username"],
     password=secrets["aio_key"],
 )
-
 
 # Initialize an Adafruit IO MQTT Client
 io = IO_MQTT(mqtt_client)

--- a/examples/dash_display_client_examples/neopixel_daughter.py
+++ b/examples/dash_display_client_examples/neopixel_daughter.py
@@ -18,12 +18,12 @@ from digitalio import DigitalInOut
 # tokens used by this Demo: CIRCUITPY_WIFI_SSID, CIRCUITPY_WIFI_PASSWORD
 #                           CIRCUITPY_AIO_USERNAME, CIRCUITPY_AIO_KEY
 secrets = {}
-for token in ["ssid", "password"]:
-    if getenv("CIRCUITPY_WIFI_" + token.upper()):
-        secrets[token] = getenv("CIRCUITPY_WIFI_" + token.upper())
-for token in ["aio_username", "aio_key"]:
-    if getenv("CIRCUITPY_" + token.upper()):
-        secrets[token] = getenv("CIRCUITPY_" + token.upper())
+for token in ["SSID", "PASSWORD"]:
+    if getenv("CIRCUITPY_WIFI_" + token):
+        secrets[token.lower()] = getenv("CIRCUITPY_WIFI_" + token)
+for token in ["AIO_USERNAME", "AIO_KEY"]:
+    if getenv("CIRCUITPY_" + token):
+        secrets[token.lower()] = getenv("CIRCUITPY_" + token)
 
 if not secrets:
     try:

--- a/examples/dash_display_client_examples/neopixel_setter_daughter.py
+++ b/examples/dash_display_client_examples/neopixel_setter_daughter.py
@@ -97,12 +97,12 @@ print(len(group))
 # tokens used by this Demo: CIRCUITPY_WIFI_SSID, CIRCUITPY_WIFI_PASSWORD
 #                           CIRCUITPY_AIO_USERNAME, CIRCUITPY_AIO_KEY
 secrets = {}
-for token in ["ssid", "password"]:
-    if getenv("CIRCUITPY_WIFI_" + token.upper()):
-        secrets[token] = getenv("CIRCUITPY_WIFI_" + token.upper())
-for token in ["aio_username", "aio_key"]:
-    if getenv("CIRCUITPY_" + token.upper()):
-        secrets[token] = getenv("CIRCUITPY_" + token.upper())
+for token in ["SSID", "PASSWORD"]:
+    if getenv("CIRCUITPY_WIFI_" + token):
+        secrets[token.lower()] = getenv("CIRCUITPY_WIFI_" + token)
+for token in ["AIO_USERNAME", "AIO_KEY"]:
+    if getenv("CIRCUITPY_" + token):
+        secrets[token.lower()] = getenv("CIRCUITPY_" + token)
 
 if not secrets:
     try:

--- a/examples/dash_display_client_examples/neopixel_setter_daughter.py
+++ b/examples/dash_display_client_examples/neopixel_setter_daughter.py
@@ -3,6 +3,7 @@
 
 import time
 import math
+from os import getenv
 import board
 import busio
 from digitalio import DigitalInOut
@@ -92,23 +93,51 @@ rect = Rect(0, 0, 160, 320, fill=0x000000)
 group.append(rect)
 print(len(group))
 
-# Get wifi details and more from a secrets.py file
-try:
-    from secrets import secrets
-except ImportError:
-    print("WiFi secrets are kept in secrets.py, please add them there!")
-    raise
+# Get wifi details and more from a settings.toml file
+# tokens used by this Demo: CIRCUITPY_WIFI_SSID, CIRCUITPY_WIFI_PASSWORD
+#                           CIRCUITPY_AIO_USERNAME, CIRCUITPY_AIO_KEY
+secrets = {}
+for token in ["ssid", "password"]:
+    if getenv("CIRCUITPY_WIFI_" + token.upper()):
+        secrets[token] = getenv("CIRCUITPY_WIFI_" + token.upper())
+for token in ["aio_username", "aio_key"]:
+    if getenv("CIRCUITPY_" + token.upper()):
+        secrets[token] = getenv("CIRCUITPY_" + token.upper())
+
+if not secrets:
+    try:
+        # Fallback on secrets.py until depreciation is over and option is removed
+        from secrets import secrets
+    except ImportError:
+        print("WiFi secrets are kept in settings.toml, please add them there!")
+        raise
 
 # PyPortal ESP32 Setup
 esp32_cs = DigitalInOut(board.ESP_CS)
 esp32_ready = DigitalInOut(board.ESP_BUSY)
 esp32_reset = DigitalInOut(board.ESP_RESET)
-spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+# Secondary (SCK1) SPI used to connect to WiFi board on Arduino Nano Connect RP2040
+if "SCK1" in dir(board):
+    spi = busio.SPI(board.SCK1, board.MOSI1, board.MISO1)
+else:
+    spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
+
+"""Use below for Most Boards"""
 status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2)
+"""Uncomment below for ItsyBitsy M4"""
+# status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
+"""Uncomment below for an externally defined RGB LED (including Arduino Nano Connect)"""
+# import adafruit_rgbled
+# from adafruit_esp32spi import PWMOut
+# RED_LED = PWMOut.PWMOut(esp, 26)
+# GREEN_LED = PWMOut.PWMOut(esp, 27)
+# BLUE_LED = PWMOut.PWMOut(esp, 25)
+# status_light = adafruit_rgbled.RGBLED(RED_LED, BLUE_LED, GREEN_LED)
+
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
 
-# Set your Adafruit IO Username and Key in secrets.py
+# Set your Adafruit IO Username and Key in settings.toml
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)
 ADAFRUIT_IO_USER = secrets["aio_username"]

--- a/examples/dash_display_client_examples/relay_daughter.py
+++ b/examples/dash_display_client_examples/relay_daughter.py
@@ -18,12 +18,12 @@ from digitalio import DigitalInOut, Direction
 # tokens used by this Demo: CIRCUITPY_WIFI_SSID, CIRCUITPY_WIFI_PASSWORD
 #                           CIRCUITPY_AIO_USERNAME, CIRCUITPY_AIO_KEY
 secrets = {}
-for token in ["ssid", "password"]:
-    if getenv("CIRCUITPY_WIFI_" + token.upper()):
-        secrets[token] = getenv("CIRCUITPY_WIFI_" + token.upper())
-for token in ["aio_username", "aio_key"]:
-    if getenv("CIRCUITPY_" + token.upper()):
-        secrets[token] = getenv("CIRCUITPY_" + token.upper())
+for token in ["SSID", "PASSWORD"]:
+    if getenv("CIRCUITPY_WIFI_" + token):
+        secrets[token.lower()] = getenv("CIRCUITPY_WIFI_" + token)
+for token in ["AIO_USERNAME", "AIO_KEY"]:
+    if getenv("CIRCUITPY_" + token):
+        secrets[token.lower()] = getenv("CIRCUITPY_" + token)
 
 if not secrets:
     try:

--- a/examples/dash_display_client_examples/relay_daughter.py
+++ b/examples/dash_display_client_examples/relay_daughter.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2021 Eva Herrada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
+from os import getenv
 import board
 import busio
 from adafruit_esp32spi import adafruit_esp32spi
@@ -13,27 +14,58 @@ from digitalio import DigitalInOut, Direction
 
 ### WiFi ###
 
-# Get wifi details and more from a secrets.py file
-try:
-    from secrets import secrets
-except ImportError:
-    print("WiFi secrets are kept in secrets.py, please add them there!")
-    raise
+# Get wifi details and more from a settings.toml file
+# tokens used by this Demo: CIRCUITPY_WIFI_SSID, CIRCUITPY_WIFI_PASSWORD
+#                           CIRCUITPY_AIO_USERNAME, CIRCUITPY_AIO_KEY
+secrets = {}
+for token in ["ssid", "password"]:
+    if getenv("CIRCUITPY_WIFI_" + token.upper()):
+        secrets[token] = getenv("CIRCUITPY_WIFI_" + token.upper())
+for token in ["aio_username", "aio_key"]:
+    if getenv("CIRCUITPY_" + token.upper()):
+        secrets[token] = getenv("CIRCUITPY_" + token.upper())
+
+if not secrets:
+    try:
+        # Fallback on secrets.py until depreciation is over and option is removed
+        from secrets import secrets
+    except ImportError:
+        print("WiFi secrets are kept in settings.toml, please add them there!")
+        raise
 
 RELAY = DigitalInOut(board.D10)
 RELAY.direction = Direction.OUTPUT
 
 # If you are using a board with pre-defined ESP32 Pins:
-esp32_cs = DigitalInOut(board.D13)
-esp32_ready = DigitalInOut(board.D11)
-esp32_reset = DigitalInOut(board.D12)
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 
-spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+# If you have an externally connected ESP32:
+# esp32_cs = DigitalInOut(board.D13)
+# esp32_ready = DigitalInOut(board.D11)
+# esp32_reset = DigitalInOut(board.D12)
+
+# Secondary (SCK1) SPI used to connect to WiFi board on Arduino Nano Connect RP2040
+if "SCK1" in dir(board):
+    spi = busio.SPI(board.SCK1, board.MOSI1, board.MISO1)
+else:
+    spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
+
 """Use below for Most Boards"""
-status_light = neopixel.NeoPixel(
-    board.NEOPIXEL, 1, brightness=0.2
-)  # Uncomment for Most Boards
+status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2)
+"""Uncomment below for ItsyBitsy M4"""
+# status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
+"""Uncomment below for an externally defined RGB LED (including Arduino Nano Connect)"""
+# import adafruit_rgbled
+# from adafruit_esp32spi import PWMOut
+# RED_LED = PWMOut.PWMOut(esp, 26)
+# GREEN_LED = PWMOut.PWMOut(esp, 27)
+# BLUE_LED = PWMOut.PWMOut(esp, 25)
+# status_light = adafruit_rgbled.RGBLED(RED_LED, BLUE_LED, GREEN_LED)
+
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
 
 
@@ -66,7 +98,6 @@ mqtt_client = MQTT.MQTT(
     username=secrets["aio_username"],
     password=secrets["aio_key"],
 )
-
 
 # Initialize an Adafruit IO MQTT Client
 io = IO_MQTT(mqtt_client)

--- a/examples/dash_display_client_examples/relay_hi_daughter.py
+++ b/examples/dash_display_client_examples/relay_hi_daughter.py
@@ -18,12 +18,12 @@ from digitalio import DigitalInOut, Direction
 # tokens used by this Demo: CIRCUITPY_WIFI_SSID, CIRCUITPY_WIFI_PASSWORD
 #                           CIRCUITPY_AIO_USERNAME, CIRCUITPY_AIO_KEY
 secrets = {}
-for token in ["ssid", "password"]:
-    if getenv("CIRCUITPY_WIFI_" + token.upper()):
-        secrets[token] = getenv("CIRCUITPY_WIFI_" + token.upper())
-for token in ["aio_username", "aio_key"]:
-    if getenv("CIRCUITPY_" + token.upper()):
-        secrets[token] = getenv("CIRCUITPY_" + token.upper())
+for token in ["SSID", "PASSWORD"]:
+    if getenv("CIRCUITPY_WIFI_" + token):
+        secrets[token.lower()] = getenv("CIRCUITPY_WIFI_" + token)
+for token in ["AIO_USERNAME", "AIO_KEY"]:
+    if getenv("CIRCUITPY_" + token):
+        secrets[token.lower()] = getenv("CIRCUITPY_" + token)
 
 if not secrets:
     try:

--- a/examples/dash_display_client_examples/relay_hi_daughter.py
+++ b/examples/dash_display_client_examples/relay_hi_daughter.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2021 Eva Herrada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
+from os import getenv
 import board
 import busio
 from adafruit_esp32spi import adafruit_esp32spi
@@ -13,27 +14,58 @@ from digitalio import DigitalInOut, Direction
 
 ### WiFi ###
 
-# Get wifi details and more from a secrets.py file
-try:
-    from secrets import secrets
-except ImportError:
-    print("WiFi secrets are kept in secrets.py, please add them there!")
-    raise
+# Get wifi details and more from a settings.toml file
+# tokens used by this Demo: CIRCUITPY_WIFI_SSID, CIRCUITPY_WIFI_PASSWORD
+#                           CIRCUITPY_AIO_USERNAME, CIRCUITPY_AIO_KEY
+secrets = {}
+for token in ["ssid", "password"]:
+    if getenv("CIRCUITPY_WIFI_" + token.upper()):
+        secrets[token] = getenv("CIRCUITPY_WIFI_" + token.upper())
+for token in ["aio_username", "aio_key"]:
+    if getenv("CIRCUITPY_" + token.upper()):
+        secrets[token] = getenv("CIRCUITPY_" + token.upper())
+
+if not secrets:
+    try:
+        # Fallback on secrets.py until depreciation is over and option is removed
+        from secrets import secrets
+    except ImportError:
+        print("WiFi secrets are kept in settings.toml, please add them there!")
+        raise
 
 RELAY = DigitalInOut(board.D10)
 RELAY.direction = Direction.OUTPUT
 
 # If you are using a board with pre-defined ESP32 Pins:
-esp32_cs = DigitalInOut(board.D13)
-esp32_ready = DigitalInOut(board.D11)
-esp32_reset = DigitalInOut(board.D12)
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 
-spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+# If you have an externally connected ESP32:
+# esp32_cs = DigitalInOut(board.D13)
+# esp32_ready = DigitalInOut(board.D11)
+# esp32_reset = DigitalInOut(board.D12)
+
+# Secondary (SCK1) SPI used to connect to WiFi board on Arduino Nano Connect RP2040
+if "SCK1" in dir(board):
+    spi = busio.SPI(board.SCK1, board.MOSI1, board.MISO1)
+else:
+    spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
+
 """Use below for Most Boards"""
-status_light = neopixel.NeoPixel(
-    board.NEOPIXEL, 1, brightness=0.2
-)  # Uncomment for Most Boards
+status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2)
+"""Uncomment below for ItsyBitsy M4"""
+# status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
+"""Uncomment below for an externally defined RGB LED (including Arduino Nano Connect)"""
+# import adafruit_rgbled
+# from adafruit_esp32spi import PWMOut
+# RED_LED = PWMOut.PWMOut(esp, 26)
+# GREEN_LED = PWMOut.PWMOut(esp, 27)
+# BLUE_LED = PWMOut.PWMOut(esp, 25)
+# status_light = adafruit_rgbled.RGBLED(RED_LED, BLUE_LED, GREEN_LED)
+
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
 
 
@@ -69,7 +101,6 @@ mqtt_client = MQTT.MQTT(
     username=secrets["aio_username"],
     password=secrets["aio_key"],
 )
-
 
 # Initialize an Adafruit IO MQTT Client
 io = IO_MQTT(mqtt_client)

--- a/examples/dash_display_client_examples/temp_humid_daughter.py
+++ b/examples/dash_display_client_examples/temp_humid_daughter.py
@@ -26,12 +26,12 @@ magtag = MagTag()
 # tokens used by this Demo: CIRCUITPY_WIFI_SSID, CIRCUITPY_WIFI_PASSWORD
 #                           CIRCUITPY_AIO_USERNAME, CIRCUITPY_AIO_KEY
 secrets = {}
-for token in ["ssid", "password"]:
-    if getenv("CIRCUITPY_WIFI_" + token.upper()):
-        secrets[token] = getenv("CIRCUITPY_WIFI_" + token.upper())
-for token in ["aio_username", "aio_key"]:
-    if getenv("CIRCUITPY_" + token.upper()):
-        secrets[token] = getenv("CIRCUITPY_" + token.upper())
+for token in ["SSID", "PASSWORD"]:
+    if getenv("CIRCUITPY_WIFI_" + token):
+        secrets[token.lower()] = getenv("CIRCUITPY_WIFI_" + token)
+for token in ["AIO_USERNAME", "AIO_KEY"]:
+    if getenv("CIRCUITPY_" + token):
+        secrets[token.lower()] = getenv("CIRCUITPY_" + token)
 
 if not secrets:
     try:

--- a/examples/dash_display_client_examples/temp_humid_daughter.py
+++ b/examples/dash_display_client_examples/temp_humid_daughter.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2021 Eva Herrada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
+from os import getenv
 import ssl
 import socketpool
 import wifi
@@ -14,20 +15,33 @@ import adafruit_sht4x
 
 ### WiFi ###
 
-# Add a secrets.py to your filesystem that has a dictionary called secrets with "ssid" and
-# "password" keys with your WiFi credentials. DO NOT share that file or commit it into Git or other
-# source control.
+# Add a settings.toml to your filesystem that has token variables "CIRCUITPY_WIFI_SSID" and
+# "CIRCUITPY_WIFI_PASSWORD" with your WiFi credentials. DO NOT share that file or commit it
+# into Git or other source control.
 # pylint: disable=no-name-in-module,wrong-import-order
 
 magtag = MagTag()
 
-try:
-    from secrets import secrets
-except ImportError:
-    print("WiFi secrets are kept in secrets.py, please add them there!")
-    raise
+# Get wifi details and more from a settings.toml file
+# tokens used by this Demo: CIRCUITPY_WIFI_SSID, CIRCUITPY_WIFI_PASSWORD
+#                           CIRCUITPY_AIO_USERNAME, CIRCUITPY_AIO_KEY
+secrets = {}
+for token in ["ssid", "password"]:
+    if getenv("CIRCUITPY_WIFI_" + token.upper()):
+        secrets[token] = getenv("CIRCUITPY_WIFI_" + token.upper())
+for token in ["aio_username", "aio_key"]:
+    if getenv("CIRCUITPY_" + token.upper()):
+        secrets[token] = getenv("CIRCUITPY_" + token.upper())
 
-# Set your Adafruit IO Username and Key in secrets.py
+if not secrets:
+    try:
+        # Fallback on secrets.py until depreciation is over and option is removed
+        from secrets import secrets
+    except ImportError:
+        print("WiFi secrets are kept in settings.toml, please add them there!")
+        raise
+
+# Set your Adafruit IO Username and Key in settings.toml
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)
 aio_username = secrets["aio_username"]

--- a/examples/dash_display_simpletest.py
+++ b/examples/dash_display_simpletest.py
@@ -3,6 +3,7 @@
 
 import time
 import ssl
+from os import getenv
 import board
 from digitalio import DigitalInOut, Direction, Pull
 import touchio
@@ -27,15 +28,28 @@ down.pull = Pull.DOWN
 back = touchio.TouchIn(board.CAP7)
 submit = touchio.TouchIn(board.CAP8)
 
-try:
-    from secrets import secrets
-except ImportError:
-    print("WiFi secrets are kept in secrets.py, please add them there!")
-    raise
+# Get wifi details and more from a settings.toml file
+# tokens used by this Demo: CIRCUITPY_WIFI_SSID, CIRCUITPY_WIFI_PASSWORD
+#                           CIRCUITPY_AIO_USERNAME, CIRCUITPY_AIO_KEY
+secrets = {}
+for token in ["ssid", "password"]:
+    if getenv("CIRCUITPY_WIFI_" + token.upper()):
+        secrets[token] = getenv("CIRCUITPY_WIFI_" + token.upper())
+for token in ["aio_username", "aio_key"]:
+    if getenv("CIRCUITPY_" + token.upper()):
+        secrets[token] = getenv("CIRCUITPY_" + token.upper())
+
+if not secrets:
+    try:
+        # Fallback on secrets.py until depreciation is over and option is removed
+        from secrets import secrets
+    except ImportError:
+        print("WiFi secrets are kept in settings.toml, please add them there!")
+        raise
 
 display = board.DISPLAY
 
-# Set your Adafruit IO Username and Key in secrets.py
+# Set your Adafruit IO Username and Key in settings.toml
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)
 aio_username = secrets["aio_username"]

--- a/examples/dash_display_simpletest.py
+++ b/examples/dash_display_simpletest.py
@@ -32,12 +32,12 @@ submit = touchio.TouchIn(board.CAP8)
 # tokens used by this Demo: CIRCUITPY_WIFI_SSID, CIRCUITPY_WIFI_PASSWORD
 #                           CIRCUITPY_AIO_USERNAME, CIRCUITPY_AIO_KEY
 secrets = {}
-for token in ["ssid", "password"]:
-    if getenv("CIRCUITPY_WIFI_" + token.upper()):
-        secrets[token] = getenv("CIRCUITPY_WIFI_" + token.upper())
-for token in ["aio_username", "aio_key"]:
-    if getenv("CIRCUITPY_" + token.upper()):
-        secrets[token] = getenv("CIRCUITPY_" + token.upper())
+for token in ["SSID", "PASSWORD"]:
+    if getenv("CIRCUITPY_WIFI_" + token):
+        secrets[token.lower()] = getenv("CIRCUITPY_WIFI_" + token)
+for token in ["AIO_USERNAME", "AIO_KEY"]:
+    if getenv("CIRCUITPY_" + token):
+        secrets[token.lower()] = getenv("CIRCUITPY_" + token)
 
 if not secrets:
     try:


### PR DESCRIPTION
I left the fallback code to read from secrets.py if the WiFi settings weren't found in settings.toml because I thought there might be learn guides that referenced example code still utilizing secrets.py.

One interesting thing I noticed was that as far as I could tell the examples in the "dash_display_client_examples" actually don't use this library.